### PR TITLE
Automate Tchap MAU metric collection

### DIFF
--- a/src/modules/indicator/indicator.service.ts
+++ b/src/modules/indicator/indicator.service.ts
@@ -87,12 +87,11 @@ function buildIndicatorService(dataSource: DataSource) {
         });
         return Promise.all(
             indicators.map((indicator) =>
-                indicatorRepository.upsert(indicator, [
-                    'product',
-                    'indicateur',
-                    'frequence_monitoring',
-                    'date',
-                ]),
+                indicatorRepository.upsert(indicator, {
+                    upsertType: 'on-conflict-do-update',
+                    skipUpdateIfNoValuesChanged: true,
+                    conflictPaths: ['product', 'indicateur', 'frequence_monitoring', 'date'],
+                }),
             ),
         );
     }

--- a/src/scripts/importStats/adaptators/tchap.adaptator.test.ts
+++ b/src/scripts/importStats/adaptators/tchap.adaptator.test.ts
@@ -1,28 +1,7 @@
 import { tchapAdaptator } from './tchap.adaptator';
 
 describe('tchapAdaptator', () => {
-    it('should format the tchap output', () => {
-        const tchapOutputRows = [
-            {
-                Month: '2023-03-01T00:00:00+01:00',
-                'Valeurs distinctes de User ID': 149550,
-            },
-        ];
-
-        const formatted = tchapAdaptator.map(tchapOutputRows);
-
-        expect(formatted).toEqual([
-            {
-                date: '2023-04-01',
-                date_debut: '2023-03-01',
-                valeur: 149550,
-                est_periode: true,
-                nom_service_public_numerique: 'tchap',
-                frequence_monitoring: 'mensuelle',
-                est_automatise: true,
-                indicateur: 'utilisateurs actifs',
-                unite_mesure: 'unité',
-            },
-        ]);
+    it('should fetch the tchap output', () => {
+        expect(tchapAdaptator.fetch()).rejects.toThrow();
     });
 });

--- a/src/scripts/importStats/adaptators/tchap.adaptator.ts
+++ b/src/scripts/importStats/adaptators/tchap.adaptator.ts
@@ -14,7 +14,7 @@ type tchapApiOutputType = Array<{
 
 async function fetch() {
     const url =
-        'https://stats.tchap.incubateur.net/public/question/beec667e-3471-4598-bd48-d119128ff7b7.json';
+        'https://stats.tchap.incubateur.net/public/question/25a6bdc7-b5e3-4444-ac9c-d6c85161220f.json';
     const result = await axios.get<tchapApiOutputType>(url);
     const tchapOutputRows = result.data;
 

--- a/src/scripts/importStats/adaptators/tchap.adaptator.ts
+++ b/src/scripts/importStats/adaptators/tchap.adaptator.ts
@@ -9,7 +9,7 @@ const productName = PRODUCTS.TCHAP.name;
 
 type tchapApiOutputType = Array<{
     Month: string;
-    'Valeurs distinctes de User ID': number;
+    'Valeurs distinctes de User ID': string;
 }>;
 
 async function fetch() {
@@ -22,9 +22,9 @@ async function fetch() {
     const indicatorDtos: any = [];
     for (const tchapOutputRow of tchapOutputRows) {
         try {
-            const date_debut = dateHandler.formatDate(tchapOutputRow.Month);
+            const date_debut = parseWrittenDate(tchapOutputRow.Month);
             const date = dateHandler.addMonth(date_debut);
-            const value = Number(tchapOutputRow['Valeurs distinctes de User ID']);
+            const value = Number(tchapOutputRow['Valeurs distinctes de User ID'].replace(/ /g, ''));
             if (isNaN(value)) {
                 throw new Error(
                     `tchapOutputRow['Valeurs distinctes de User ID'] ${tchapOutputRow['Valeurs distinctes de User ID']} is NaN`,
@@ -52,5 +52,30 @@ async function fetch() {
 
     return indicatorDtos;
 }
+
+function parseWrittenDate(writtenDate: string) {
+    const YEAR_REGEX = /^[0-9]{4}$/;
+    const [writtenMonth, year] = writtenDate.split(', ');
+    if (!writtenMonth || !year || !year.match(YEAR_REGEX) || !monthMapping[writtenMonth]) {
+        throw new Error(`Could not parse written date ${writtenDate}`);
+    }
+    const month = monthMapping[writtenMonth];
+    return `${year}-${month}-01`;
+}
+
+const monthMapping: Record<string, string> = {
+    'avr.': '04',
+    mai: '05',
+    juin: '06',
+    'juil.': '07',
+    août: '08',
+    'sept.': '09',
+    'oct.': '10',
+    'nov.': '11',
+    'déc.': '12',
+    'janv.': '01',
+    'févr.': '02',
+    mars: '03',
+};
 
 export { tchapAdaptator };


### PR DESCRIPTION
# Context

Les métriques de Tchap ne remontent plus automatiquemnt depuis plusieurs mois. J'aimerais automatiser la collecte de la métrique "monthly active users" de Tchap. 

# Implémentation

- [x] changer l'url pour une URL fonctionnelle
- [x] vérifier avec les tests que le code d'avant fonctionne avec la nouvelle URL
- [x] activer un CRON pour GET la donnée automatiquement au premier du mois