### PR TITLE
(migration) migrate products page

### DIFF
--- a/django/config/urls.py
+++ b/django/config/urls.py
@@ -1,30 +1,11 @@
-"""
-URL configuration for config project.
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/5.2/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
-"""
-
-from django.contrib import admin
-from django.urls import path, re_path
+from django.urls import include, path, re_path
 from django.conf import settings
 
-from core import views
+from core import urls as core_urls
 
 from revproxy.views import ProxyView
 
 urlpatterns = [
-    path("admin/", admin.site.urls),
-    path("accessibility", views.accessibility, name="accessibility"),
+    path("", include(core_urls)),
     re_path(r"(?P<path>.*)", ProxyView.as_view(upstream=settings.UPSTREAM_EXPRESS)),
 ]

--- a/django/core/models.py
+++ b/django/core/models.py
@@ -70,6 +70,12 @@ class Product(BaseModel):
         verbose_name_plural = _("products")
         managed = False
 
+    @property
+    def last_indicators(self):
+        recent_indicators = Indicator.objects.filter(product=self).order_by("date")
+        last_entry_date = recent_indicators[0].date
+        return recent_indicators.filter(date=last_entry_date)
+
 
 class Indicator(BaseModel):
     product = models.ForeignKey(

--- a/django/core/templates/core/products.html
+++ b/django/core/templates/core/products.html
@@ -1,0 +1,61 @@
+{% extends "core/base.html" %}
+{% load i18n static %}
+
+{% block title %}
+  <title>Liste des produits</title>
+{% endblock title %}
+
+{% block content %}
+<div class="fr-table">
+    <div class="fr-table__wrapper">
+        <div class="fr-table__container">
+            <div class="fr-table__content">
+                <table>
+                    <caption>Produits référencés</caption>
+                    <thead>
+                        <th scope="col">Produit</th>
+                        <th scope="col">Date dernière stat</th>
+                        <th scope="col">Dernière stat</th>
+                        <th scope="col">Récupération auto ?</th>
+                    </thead>
+                    <tbody>
+                        {% for product in products %}
+                        <tr>
+                            <td>{{ product.nom_service_public_numerique }}</td>
+                            
+                            {% if product.last_indicators %}
+                                <td>
+                                    {{ product.last_indicators.0.date }}
+                                </td>
+                                <td>
+                                    <ul>
+                                        {% for indicator in  product.last_indicators %}
+                                            <li>{{ indicator.valeur|floatformat:"0" }} {{ indicator.indicateur }}</li>
+                                        {% endfor %}
+                                    </ul>
+                                </td>
+                                <td>
+                                    <ul>
+                                        {% for indicator in product.last_indicators %}
+                                        <li>
+                                            {{ indicator.est_automatise }}
+                                        </li>                                            
+                                        {% endfor %}
+                                    </ul>
+                                    
+                                </td>
+                            </td>    
+                            {% else %}
+                            <td>N/A</td>
+                            <td>N/A</td>
+                            <td>N/A</td>
+                            {% endif %}
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock content %}

--- a/django/core/urls.py
+++ b/django/core/urls.py
@@ -1,0 +1,12 @@
+"""Core URL Configuration"""
+
+from django.urls import path
+from django.contrib import admin
+
+from core import views
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+    path("accessibility", views.accessibility, name="accessibility"),
+    path("products", views.products, name="products"),
+]

--- a/django/core/views.py
+++ b/django/core/views.py
@@ -1,9 +1,16 @@
 from django.http import HttpResponse, HttpRequest
 from django.shortcuts import render
+from core.models import Product
 
 
 def index(request):
     return render(request, "core/index.html")
+
+
+def products(request: HttpRequest) -> HttpResponse:
+    products = Product.objects.all()
+
+    return render(request, "core/products.html", context={"products": products})
 
 
 def accessibility(request: HttpRequest) -> HttpResponse:


### PR DESCRIPTION
# Goal 

Recreate products page in Django as part of the "Express => Django" migration effort (see #22)

# Screenshots

### In express
<img width="1339" height="571" alt="image" src="https://github.com/user-attachments/assets/bddb07e0-9b10-4c81-9b16-d8dd425303bd" />

### In Django
<img width="1239" height="516" alt="image" src="https://github.com/user-attachments/assets/2f82585e-919b-42dc-9a8c-30b8d56ba2a5" />
