### PR TITLE
(api) filter indicators endpoint by indicateur

### DIFF
--- a/django/core/api/viewsets.py
+++ b/django/core/api/viewsets.py
@@ -41,6 +41,10 @@ class IndicatorViewSet(
         if product_slug := self.kwargs.get("product_id"):
             product = models.Product.objects.get(slug=product_slug)
             queryset = queryset.filter(productid=product)
+
+        query = self.request.query_params
+        if indicateur := query.get("indicateur"):
+            queryset = queryset.filter(indicateur=indicateur)
         return queryset
 
     def perform_create(self, serializer):

--- a/django/core/tests/api/indicators/test_api_indicators.py
+++ b/django/core/tests/api/indicators/test_api_indicators.py
@@ -44,6 +44,33 @@ def test_api_indicators_list__anonymous_ok():
     )
 
 
+def test_api_indicators_list__filter_ok():
+    """Can filter by indicateur."""
+    product = factories.ProductFactory()
+    factories.IndicatorFactory(indicateur="somethingelse", productid=product)
+    indicator = factories.IndicatorFactory(productid=product)
+
+    response = APIClient().get(
+        f"/api/products/{product.slug}/indicators/?indicateur=utilisateurs%20actifs"
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.json()) == 1
+    assert response.json() == [
+        {
+            "id": str(indicator.id),
+            "indicateur": indicator.indicateur,
+            "valeur": indicator.valeur,
+            "unite_mesure": indicator.unite_mesure,
+            "frequence_monitoring": indicator.frequence_monitoring,
+            "date": str(indicator.date),
+            "date_debut": str(indicator.date_debut),
+            "est_periode": indicator.est_periode,
+            "est_automatise": indicator.est_automatise,
+            "productid": str(indicator.productid.id),
+        }
+    ]
+
+
 # CREATE
 def test_api_indicators_create__anonymous_cannot_create():
     """Anonymous users should not be allowed to create indicators."""


### PR DESCRIPTION
Les indicateurs sont actuellement pêle-mêle. Ajout d'un filtre pour pouvoir les filtrer par indicateur ("utilisateurs actifs", "nombre de plis, etc")