### PR TITLE
Create admin api key

### DIFF
--- a/django/.env.example
+++ b/django/.env.example
@@ -3,3 +3,4 @@ DEBUG=False
 DATABASE_URL=postgresql://db_user:db_password@db_host:db_port/db_name
 UPSTREAM_EXPRESS=your-upstream-url
 ENVIRONMENT="Development"
+ADMIN_API_KEY=your-secret-api-key

--- a/django/config/settings.py
+++ b/django/config/settings.py
@@ -152,6 +152,7 @@ REST_FRAMEWORK = {
 }
 
 API_KEY_CUSTOM_HEADER = "HTTP_X_API_KEY"
+ADMIN_API_KEY = os.getenv("ADMIN_API_KEY")
 
 # Setting for revproxy
 UPSTREAM_EXPRESS = os.getenv("UPSTREAM_EXPRESS")

--- a/django/core/api/permissions.py
+++ b/django/core/api/permissions.py
@@ -2,7 +2,7 @@ from rest_framework import permissions
 from rest_framework import exceptions
 from core import models
 from django.shortcuts import get_object_or_404
-
+from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 
@@ -18,6 +18,9 @@ class HasValidAPIKeyOrReadOnly(permissions.BasePermission):
 
         product = get_object_or_404(models.Product, slug=view.kwargs["product_slug"])
         if key := request.headers.get("X-Api-Key"):
+            if request.headers.get("X-Api-Key") == settings.ADMIN_API_KEY:
+                return True
+
             try:
                 api_key = models.ProductAPIKey.objects.get_from_key(key)
             except models.ProductAPIKey.DoesNotExist:

--- a/django/docs/envoi_de_fichiers.md
+++ b/django/docs/envoi_de_fichiers.md
@@ -4,14 +4,14 @@
 
 Certains indicateurs ne sont pas récupérés automatiquement par notre API en début de mois mais générés à partir de fichiers qui nous sont envoyés. C'est notamment le cas des indicateurs de France Transfert. Vous trouverez ci-dessous quelques explications pour configurer vos appels.
 
-## Format d'appel
+## Exemple d'appel
 
 ```bash
 curl -L 'http://stats.beta.numerique.gouv.fr/api/products/france-transfert/submission/' 
 -H 'Content-Type: text/csv' 
 -H 'x-api-key: <votre-clé-secrète>' 
 -H 'Content-Disposition: attachment; filename=ip-127-0-0-1_FranceTransfert_2025-07-14_upload_stats.csv' 
--d '@/home/marie/Dev/operateur/statistiques-impact/django/core/tests/api/examples/ip-127-0-0-1_FranceTransfert_2025-07-24_upload_stats.csv'
+-d '@/home/france-transfert/statistiques/ip-127-0-0-1_FranceTransfert_2025-07-24_upload_stats.csv'
 ```
 
 > [!NOTE]   


### PR DESCRIPTION
To avoid having to create/handle an ProductAPIKey for each product, we set an "ADMIN_API_KEY", which has permission to create/delete indicators on every product.