### PR TITLE
Separate Resana users as reported by ProConnect and total users

### DIFF
--- a/express/Procfile
+++ b/express/Procfile
@@ -1,1 +1,0 @@
-postdeploy: npm run migration:run && npm run script:insertProducts

--- a/express/src/scripts/importStats/adaptators/suite.adaptator.ts
+++ b/express/src/scripts/importStats/adaptators/suite.adaptator.ts
@@ -31,10 +31,10 @@ function buildSuiteAdaptator(productId: SUITE_PRODUCT_ID) {
         const url =
             'https://stats.moncomptepro.beta.gouv.fr/public/question/0e3cee98-df38-4d57-8c37-d38c5a2d3231.json';
         const data = await cache.fetch<suiteNumeriqueOutputApiType>(url);
-        const indicatorName = 'utilisateurs actifs';
+        var indicatorName = 'utilisateurs actifs';
 
         if (productName == 'resana' || productName == 'france-transfert'){
-            const indicatorName = 'utilisateurs actifs via PC';
+            indicatorName = 'utilisateurs actifs via PC';
         }
         const indicatorDtos: any = [];
         try {

--- a/express/src/scripts/importStats/adaptators/suite.adaptator.ts
+++ b/express/src/scripts/importStats/adaptators/suite.adaptator.ts
@@ -34,7 +34,7 @@ function buildSuiteAdaptator(productId: SUITE_PRODUCT_ID) {
         var indicatorName = 'utilisateurs actifs';
 
         if (productName == 'resana' || productName == 'france-transfert'){
-            indicatorName = 'utilisateurs actifs via PC';
+            indicatorName = 'utilisateurs actifs via ProConnect';
         }
         const indicatorDtos: any = [];
         try {


### PR DESCRIPTION
For now, only a few percentage of Resana's total user log in via ProConnect. When surveying all Suite products on ProConnect's metabase, save Resana and France Transfert's active users as "utilisateurs actifs via ProConnect"